### PR TITLE
Merkblatt Mitgliederbeitraege

### DIFF
--- a/site/content/news/2012-12-15_gruendung/de.md
+++ b/site/content/news/2012-12-15_gruendung/de.md
@@ -72,6 +72,10 @@ präsentieren; auf dem Hacker-Kongress werden zwischen Weihnachten und Neujahr
 
 - <http://ruum42.ch/>
 
+**Hackerspace Ostermundigen**
+
+- <http://www.eastermundigen.ch/>
+
 **Chaostreff Bern:**
 
-- <http://www.chaosbern.ch/>
+- <https://www.chaostreffbern.ch/>

--- a/site/content/news/2015-09-15_merkblatt/de.md
+++ b/site/content/news/2015-09-15_merkblatt/de.md
@@ -1,0 +1,44 @@
+Title: Merkblatt zu den Mitgliederbeiträgen
+
+An zahlreichen Sitzungen des CCC-CH haben wir das Thema der Mitgliederbeiträge angesprochen.
+In diesem Merkblatt haben wir alle Informationen zusammengetragen und (hoffentlich) klar verständlich niedergeschrieben.
+(Für eine aktualisierte Version dieses Merkblattes, inklusive Diskussionen, siehe bitte [\[7\]][7])
+
+
+## Target audience
+Jedes Mitglied des CCC-CH soll gemäss den Statuten [\[6\]][6] jährlich einen Mitgliederbeitrag leisten. Dieser berechnet sich anhand der Anzahl Personen, die das Mitglied vertritt (siehe "Wie viel ist zu bezahlen?").
+Dieses Dokument soll den Kassiers der CCC-CH Mitglieder beim Berechnen der einzuzahlenden Summe und beim Erstellen der Transaktion helfen.
+
+## Wer soll die Einzahlung tätigen?
+Die Einzahlungen erfolgen pro Mitglied. Typischerweise bedeutet das, dass der Kassier des Mitgliedes die Beiträge aller vertretenen Personen einsammelt und dann eine Überweisung tätigt. Er kann dies auch aus seinem allgemeinen Budget tätigen.
+Es gibt also pro Mitglied und Jahr eine Einzahlung. Die von einem Mitglied vertretenen Personen sollen den Betrag nicht selbst ueberweisen. Dadurch soll verhindert werden, dass eine zentrale Liste aller Schweizer Hacker entsteht.
+
+## Wie viel ist zu bezahlen?
+Pro vertretene Person sind CHF 5.- pro Jahr zu bezahlen, gemäss [\[0\]][0].
+
+## Wohin hat die Ueberweisung zu erfolgen?
+Zur Überweisung der Mitgliederbeiträge sind folgende Kontoinformationen zu verwenden:
+
+```
+Postkonto 60-605459-2
+Chaos Computer Club Schweiz
+Birsfelderstrasse 6
+CH-4132 Muttenz
+IBAN: CH54 0900 0000 6060 5459 2
+```
+
+## Bis wann ist zu bezahlen?
+Die Mitgliederbeiträge müssen gemäss [\[4\]][4] bis zum 1. August überwiesen werden.
+
+## Was ist mit neu beitretenden Personen?
+Für Personen, die dem Mitglied vor dem 1. August beitreten ist der volle Mitgliederbeitrag für das laufende Jahr zu erstatten.
+Tritt eine Person aber nach dem 1. August bei, so muss für diese für das laufende Jahr kein Mitgliederbeitrag entrichtet werden.
+
+[0]: "Email von marc@ccczh.ch an swiss-chaos@chaostreff.ch, 2014-06-20, Betreff: CCC-CH GV 2014 Protokoll Status"
+[1]: https://pads.ccc.de/uL3MlRqsFb "CCC-CH Treffen im Ruum42 (St.Gallen) am 14.02.2015"
+[2]: https://pads.ccc.de/2015-04-swisschaos "Swisschaos-gettogether 2015-04-25"
+[3]: https://pads.ccc.de/jYHXGdg8qt "Chaosversammlung CCC Schweiz vom 2015-06-14"
+[4]: https://pads.ccc.de/jYHXGdg8qt "CCC-CH GV 2015"
+[5]: http://ccc-ch.ch/impressum.html "CCC-CH Kontoinformationen"
+[6]: http://ccc-ch.ch/statuten.html "CCC-CH Statuten"
+[7]: https://pads.ccc.de/bYDktJ2riW "Merkblatt: CCC-CH Mitgliederbeiträge auf dem Chaospad"


### PR DESCRIPTION
Ich habe das Merkblatt zu den Mitglieder Beitraegen nach Markdown uebertragen. Leider habe ich keinen besonders passenden Ort dafuer gefunen, also hab ich s einfach in die News rein gemacht.

Ausserdem habe ich den Eastermundigen wieder verlinkt und die URL zum Chaostreff Bern aktualisiert.