### PR TITLE
Members list

### DIFF
--- a/content/pages/de/homepage.md
+++ b/content/pages/de/homepage.md
@@ -45,32 +45,11 @@ einem eigenen Stand präsentieren; auf dem Hacker-Kongress werden zwischen Weihn
 
 ## Hintergrund-Informationen / Links
 
+### Unsere Mitglieder
+
+  Konsultiere auch die Webseiten unserer [Migliedsorgnisationen](members.html) für weitere Informationen.
+
 ### Chaos Computer Club e.V. (Deutschland)
 
   * [https://ccc.de/](https://ccc.de/)
   * [https://de.wikipedia.org/wiki/Chaos_Computer_Club](https://de.wikipedia.org/wiki/Chaos_Computer_Club)
-
-### Chaos Computer Club Zürich
-
-  * [https://www.ccczh.ch/](https://www.ccczh.ch/)
-  * [https://de.wikipedia.org/wiki/CCCZH](https://de.wikipedia.org/wiki/CCCZH)
-
-### Chaostreff Basel
-
-  * [https://wiki.chaostreff.ch/Chaostreff](https://wiki.chaostreff.ch/Chaostreff)
-
-### Hackburg (Hackerspace Freiburg)
-
-  * [http://www.hackburg.ch/](http://www.hackburg.ch/)
-
-### Ruum42 (Hackerspace St. Gallen)
-
-  * [https://ruum42.ch/](https://ruum42.ch/)
-
-### Chaostreff Bern
-
-  * [https://www.chaostreffbern.ch/](https://www.chaostreffbern.ch/)
-
-### Eastermundigen (Hackerspace Bern)
-
-  * [http://www.eastermundigen.ch/](http://www.eastermundigen.ch/)

--- a/content/pages/de/members.md
+++ b/content/pages/de/members.md
@@ -1,0 +1,44 @@
+Title: Mitglieder
+Slug: members
+Lang: de
+Date: 2015-09-20
+Modified: 2015-09-20
+
+Folgende Organisationen sind Mitglieder im CCC-CH
+
+### Chaos Computer Club Zürich
+
+  * [https://www.ccczh.ch/](https://www.ccczh.ch/)
+  * [https://de.wikipedia.org/wiki/CCCZH](https://de.wikipedia.org/wiki/CCCZH)
+
+### Chaostreff Basel
+
+  * [https://wiki.chaostreff.ch/Chaostreff](https://wiki.chaostreff.ch/Chaostreff)
+
+### Hackburg (Hackerspace Freiburg)
+
+  * [http://www.hackburg.ch/](http://www.hackburg.ch/)
+
+### Ruum42 (Hackerspace St. Gallen)
+
+  * [https://ruum42.ch/](https://ruum42.ch/)
+
+### Chaostreff Bern
+
+  * [https://www.chaostreffbern.ch/](https://www.chaostreffbern.ch/)
+
+### Hackerfunk
+
+  * [http://hackerfunk.ch/](http://hackerfunk.ch/)
+
+### Chaostreff Winterthur
+
+  * [http://chaostreff.dingens.org/](http://chaostreff.dingens.org/)
+
+### Coredump (Hackerspace Rapperswil)
+
+  * [https://www.coredump.ch/](https://www.coredump.ch/)
+
+### Eastermundigen (Hackerspace Bern)
+
+  * [http://www.eastermundigen.ch/](http://www.eastermundigen.ch/)

--- a/content/pages/de/members.md
+++ b/content/pages/de/members.md
@@ -23,10 +23,6 @@ Folgende Organisationen sind Mitglieder im CCC-CH
 
   * [https://ruum42.ch/](https://ruum42.ch/)
 
-### Chaostreff Bern
-
-  * [https://www.chaostreffbern.ch/](https://www.chaostreffbern.ch/)
-
 ### Hackerfunk
 
   * [http://hackerfunk.ch/](http://hackerfunk.ch/)
@@ -35,10 +31,18 @@ Folgende Organisationen sind Mitglieder im CCC-CH
 
   * [http://chaostreff.dingens.org/](http://chaostreff.dingens.org/)
 
+### Odenwilusenz (Hackerspace Beringen)
+
+  * [http://www.odenwilusenz.ch/](http://www.odenwilusenz.ch/)
+
 ### Coredump (Hackerspace Rapperswil)
 
   * [https://www.coredump.ch/](https://www.coredump.ch/)
 
-### Eastermundigen (Hackerspace Bern)
+### Chaostreff Bern
+
+  * [https://www.chaostreffbern.ch/](https://www.chaostreffbern.ch/)
+
+### Eastermundigen (Hackerspace Ostermundigen)
 
   * [http://www.eastermundigen.ch/](http://www.eastermundigen.ch/)

--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -19,6 +19,7 @@ MENUITEMS = (
                 ('FAQ', 'faq.html'),
                 ('Statuten', 'statuten.html'),
                 ('Protokolle', 'protokolle.html'),
+                ('Mitglieder', 'members.html'),
               ]),
               ('Medienmitteilungen', 'medien.html', None),
               ('Pressreview', 'pressreview.html', None),

--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -15,7 +15,7 @@ PAGE_PATHS = ['pages']
 # Menu
 MENUITEMS = (
               ('Home', 'index.html', None),
-              ('CCC', '#', [
+              ('CCC-CH', '#', [
                 ('FAQ', 'faq.html'),
                 ('Statuten', 'statuten.html'),
                 ('Protokolle', 'protokolle.html'),


### PR DESCRIPTION
I created a dedicated list of member organisations. I also updated the list to now include all current member organisations (or at least the ones I can remember). With there now being a list of members, I removed the old list from the homepage and put in a link to the complete list instead. Lastly, I renamed the 'CCC' menupoint to now be called 'CCC-CH'.