### PR TITLE
Added a list of gettogethers

### DIFF
--- a/content/pages/de/intern/gettogether.md
+++ b/content/pages/de/intern/gettogether.md
@@ -1,0 +1,34 @@
+Title: Gettogether
+Slug: gettogether
+Lang: de
+Date: 2015-09-20
+Modified: 2015-09-21
+
+Ca. alle zwei Monate führt der CCC-CH ein Gettogether durch. Ein Treffen aller vertretenen Chaostreffs und Hackerspaces. Dabei werden Themen diskutiert die den CCC-CH zur Zeit beschäftigen. Die Mitglieder können Projekte vorstellen, Events und Ausflüge werden geplant. Die Gettogether werden jedes Mal von einem anderen Mitglied des CCC-CH organisiert und finden deshalb auch jedes Mal an einem anderen Ort statt.
+
+## Kommende Gettogether
+
+ * November 2015, Basel
+    * **Wann:** Samstag, 2015-11-14
+    * **Wo:** Chaoten und R.A.I.F. Basis, Birsfelderstrasse 6, 4132 Muttenz
+    * **Traktanden:**
+
+## Vergangene Gettogether
+
+ * September 2015, Bern
+    * **Wann:** Samstag, 2015-09-19 ab 14:00 Uhr
+    * **Wo:** Autonome Schule denk:mal, Lagerweg 12, 3013 Bern
+    * **Traktanden:** [Pad](https://pads.ccc.de/ZUqtT51b7T)
+ * Juni 2015, Biel/Bienne (GV)
+    * **Wann:** Sonntag, 2015-06-14 ab 10:00 Uhr im Ramen der [Cosin](https://www.cosin.ch/)
+    * **Wo:** Villa Ritter in Biel/Bienne
+    * **Traktanden:** [Pad](https://pads.ccc.de/jYHXGdg8qt)
+ * April 2015, Zürich
+    * **Wann:** Samstag, 2015-04-25 ab 13:00 Uhr
+    * **Wo:** CCCZH, Röschibachstrasse 26, 8037 Zurich
+    * **Traktanden:** [Pad](https://pads.ccc.de/2015-04-swisschaos)
+ * Februar 2015, St. Gallen
+    * **Wann:** Samstag, 2015-02-14 ab 13:00 Uhr
+    * **8Wo:** Ruum42, Andreasstrasse 5, St.Gallen 
+    * **Traktanden:** [pad](https://pads.ccc.de/uL3MlRqsFb)
+

--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -24,6 +24,7 @@ MENUITEMS = (
               ('Intern', '#', [
                 ('Protokolle', 'protokolle.html'),
                 ('Mitgliederbeiträge', 'mitgliederbeitraege.html'),
+                ('Gettogether', 'gettogether.html'),
               ]),
             )
 


### PR DESCRIPTION
This list shows upcoming and past gettogethers. It includes location information and a link to the pad. The intention of this list is to make it easier to find the protocols of old gettogethers.