### PR TITLE
Pressreview tool

### DIFF
--- a/add_pressreview.py
+++ b/add_pressreview.py
@@ -2,6 +2,7 @@
 
 import argparse
 import io
+import os
 import re
 import sys
 import unicodedata
@@ -31,6 +32,10 @@ class PressReview:
                 result.append(word)
         slug = '%s_%s' % (self.date, '-'.join(result))
         return slug.encode('ascii', 'ignore').decode('ascii')
+
+    @property
+    def filename(self):
+        return '%s.md' % self.slug
 
     def get_text(self):
         text = io.StringIO()
@@ -103,7 +108,22 @@ if __name__ == '__main__':
     pr = PressReview(args.date, args.publisher, args.title, args.url)
     text = pr.get_text()
 
+    # Dry run
     if args.dry_run:
         print(text)
-    else:
-        print('Generating %s...' % 'NOT YET IMPLEMENTED')
+        sys.exit(0)
+
+    # Calculate target filepath
+    module_path = os.path.dirname(os.path.abspath(__file__))
+    target_dir = os.path.join(module_path, 'content/de/pressreview/')
+    target_file = os.path.join(target_dir, pr.filename)
+    print('Writing %s...' % target_file)
+
+    # Verify that file does not yet exist
+    if os.path.isfile(target_file):
+        print('Target file already exists! Aborting.')
+        sys.exit(1)
+
+    # Write file
+    with open(target_file, 'w', encoding='utf-8') as f:
+        f.write(text)

--- a/add_pressreview.py
+++ b/add_pressreview.py
@@ -1,5 +1,10 @@
 #!/usr/bin/env python3
+
+import re
+import sys
 import argparse
+import urllib.request
+import urllib.error
 
 
 def get_parser():
@@ -7,16 +12,53 @@ def get_parser():
     Build an argument parser.
     """
     parser = argparse.ArgumentParser(description='Add a new press review entry.')
-    parser.add_argument('date', nargs=1, help='The publication date (YYYY-MM-DD)')
-    parser.add_argument('publisher', nargs=1, help='The publisher, e.g. "20 Minuten" or "NZZ"')
-    parser.add_argument('title', nargs=1, help='The publication title')
-    parser.add_argument('url', nargs=1, help='The URL')
+    parser.add_argument('date', help='The publication date (YYYY-MM-DD)')
+    parser.add_argument('publisher', help='The publisher, e.g. "20 Minuten" or "NZZ"')
+    parser.add_argument('title', help='The publication title')
+    parser.add_argument('url', help='The URL')
     parser.add_argument('-d', '--dry-run', action='store_true', default=False,
             help='Only print press review entry, don\'t save it')
+    parser.add_argument('-f', '--force', action='store_true', default=False,
+            help='Skip validation')
     return parser
+
+
+class Validator:
+    """
+    A class to validate the arguments.
+    """
+    def __init__(self, args):
+        self.args = args
+
+    def _validate_date(self):
+        year_re = r'(19|20)\d\d'
+        month_re = r'(0[1-9]|1[012])'
+        day_re = r'(0[1-9]|[12][0-9]|3[01])'
+        if not re.match('^%s-%s-%s$' % (year_re, month_re, day_re), self.args.date):
+            print('Invalid date: %s' % self.args.date)
+            print('Date must be in the YYYY-MM-DD format.')
+            sys.exit(1)
+
+    def _validate_url(self):
+        try:
+            urllib.request.urlopen(self.args.url)
+        except urllib.error.URLError as e:
+            print('Invalid or dead URL: %s' % self.args.url)
+            print(str(e))
+            sys.exit(1)
+
+    def validate(self):
+        self._validate_date()
+        self._validate_url()
 
 
 if __name__ == '__main__':
 
+    # Parse arguments
     parser = get_parser()
     args = parser.parse_args()
+
+    # Validate arguments
+    if not args.force:
+        v = Validator(args)
+        v.validate()

--- a/add_pressreview.py
+++ b/add_pressreview.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+import argparse
+
+
+def get_parser():
+    """
+    Build an argument parser.
+    """
+    parser = argparse.ArgumentParser(description='Add a new press review entry.')
+    parser.add_argument('date', nargs=1, help='The publication date (YYYY-MM-DD)')
+    parser.add_argument('publisher', nargs=1, help='The publisher, e.g. "20 Minuten" or "NZZ"')
+    parser.add_argument('title', nargs=1, help='The publication title')
+    parser.add_argument('url', nargs=1, help='The URL')
+    parser.add_argument('-d', '--dry-run', action='store_true', default=False,
+            help='Only print press review entry, don\'t save it')
+    return parser
+
+
+if __name__ == '__main__':
+
+    parser = get_parser()
+    args = parser.parse_args()


### PR DESCRIPTION
Hier das Tool, das ich im #30 und #33 angesprochen habe.

Es generiert automatisch einen Press Review Eintrag.

URL wird durch Request validiert.

Python 3 required, keine weiteren Dependencies.

Usage:

```
usage: add_pressreview.py [-h] [-d] [-f] date publisher title url

Add a new press review entry.

positional arguments:
  date           The publication date (YYYY-MM-DD)
  publisher      The publisher, e.g. "20 Minuten" or "NZZ"
  title          The publication title
  url            The URL

optional arguments:
  -h, --help     show this help message and exit
  -d, --dry-run  Only print press review entry, don't save it
  -f, --force    Skip validation
```