### PR TITLE
Aenderungen aus dem Statuten Repository uebernommen

### DIFF
--- a/content/pages/de/ccc-ch/statuten.md
+++ b/content/pages/de/ccc-ch/statuten.md
@@ -2,9 +2,9 @@ Title: Statuten
 Slug: statuten
 Lang: de
 Date: 2012-10-27
-Modified: 2014-10-04
+Modified: 2016-06-11
 
-Statuten des CCC CH per 27.10.2012
+Statuten des CCC CH per 11.06.2016
 
 ## 1 Name und Sitz des Verbands
 
@@ -63,14 +63,17 @@ Organe des Vereins sind:
 ## 7 Die Chaosversammlung
 
 Die ordentliche Chaosversammlung findet jährlich im ersten Quartal des
-Geschäftsjahres statt. Dieses entspricht dem Kalenderjahr. Eine
-ausserordentliche Chaosversammlung kann vom Vorstand oder von einem Fünftel der
+von Juni bis Mai laufenden Geschäftsjahres statt. So die Veranstaltung
+«Chaos Singularity (CoSin)» organisiert wird, findet sie während dieser statt.
+
+Eine ausserordentliche Chaosversammlung kann vom Vorstand oder von einem Fünftel der
 Mitglieder einberufen werden. Die Organisation obliegt dem Vorstand.
 
 Jedes Mitglied stellt zwei Delegierte mit je einer Stimme.
 
 Die Einladung muss den Mitgliedern spätestens 42 Tage vor der Chaosversammlung
-vorliegen.
+vorliegen; der CfP zur «Chaos Singularity (CoSin)» gilt als 
+Einladung zur Chaosversammlung.
 
 Die Chaosversammlung kann elektronische Verfahren der Beschlussfassung der
 physischen Versammlung gleichsetzen. Den Delegierten stehen zur Stimmabgabe
@@ -108,3 +111,8 @@ ordentlichen Chaosversammlung.
 
 Die Liquidation erfolgt durch den Vorstand. Das Vereinsvermögen fällt an eine
 Institution mit vergleichbaren Zielen.
+
+## Übergangsbestimmungen
+
+Das Geschäftsjahr 2016 wird bis Mai 2017 verlängert.
+


### PR DESCRIPTION
Die an der GV 2016 beschlossenen Aenderungen an den Statuten. Natuerlich nicht selbst geschrieben, sondern aus dem Statuten Repository kopiert.