### PR TITLE
Fix rsync permissions on upload

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,7 +89,7 @@ ssh_upload: publish
 	scp -P $(SSH_PORT) -r $(OUTPUTDIR)/* $(SSH_USER)@$(SSH_HOST):$(SSH_TARGET_DIR)
 
 rsync_upload: publish
-	rsync -e "ssh -p $(SSH_PORT)" -P --chmod=ug=rwX,o=rX --group=webadmins -rvzc --delete $(OUTPUTDIR)/ $(SSH_USER)@$(SSH_HOST):$(SSH_TARGET_DIR) --cvs-exclude
+	rsync -e "ssh -p $(SSH_PORT)" -P -p --chmod=ug=rwX,o=rX --group=webadmins -rvzc --delete $(OUTPUTDIR)/ $(SSH_USER)@$(SSH_HOST):$(SSH_TARGET_DIR) --cvs-exclude
 
 dropbox_upload: publish
 	cp -r $(OUTPUTDIR)/* $(DROPBOX_DIR)


### PR DESCRIPTION
Without the `-p` parameter, the `--chmod` has no effect.

Bitte noch nicht mergen, ich warte noch auf eine Antwort von Obri um die Konfiguration testen zu können.

@gnurbs FYI