### PR TITLE
April17 gettogether

### DIFF
--- a/content/pages/de/intern/gettogether.md
+++ b/content/pages/de/intern/gettogether.md
@@ -70,4 +70,8 @@ Ca. alle zwei Monate führt der CCC-CH ein Gettogether durch. Ein Treffen aller 
     * **Wann:** Samstag, 2015-02-14 ab 13:00 Uhr
     * **Wo:** Ruum42, Andreasstrasse 5, St.Gallen 
     * **Traktanden:** [pad](https://pads.ccc.de/uL3MlRqsFb)
+ * Oktorber 2013, Beringen
+    * **Wann:** Sonntag, 2013-10-13
+    * **Wo:** [Odenwilusenz (Hackerspace Beringen)](http://www.odenwilusenz.ch/)
+    * **Traktanden:** [E-Mail von nobody_su](oktober13_gettogether.html)
 

--- a/content/pages/de/intern/gettogether.md
+++ b/content/pages/de/intern/gettogether.md
@@ -8,11 +8,11 @@ Ca. alle zwei Monate führt der CCC-CH ein Gettogether durch. Ein Treffen aller 
 
 ## Kommende Gettogether
 
- * Dezember 2016, Hamburg
-    * **Wann:** Donnerstag, 2016-12-29 ab 16:00 Uhr (Tag 3 des 33c3)
-    * **Wo:** [Hall C.1](https://events.ccc.de/congress/2016/wiki/Room:Hall_C.1), 33c3, CCH Congress Center Hamburg, Deutschland
-    * **Traktanden:** [Pad](https://pads.ccc-ch.ch/public_pad/33c3-gettogether)
-    * **Link:** [Congress wiki](https://events.ccc.de/congress/2016/wiki/Session:CCC-CH_Gettogether)
+ *  April 2017, Beringen
+    * **Wann:** Samstag, 2017-04-29 ab 14:00 Uhr
+    * **Wo:** [Restuarant Bahnhof](http://www.openstreetmap.org/way/251950383), Wiesengasse 12, 8222 Beringen
+    * **Organisator:** [Odenwilusenz (Hackerspace Beringen)](http://www.odenwilusenz.ch/)
+    * **Traktanden:** [Pad](https://pads.ccc-ch.ch/public_pad/april17_gettogether)
  * Juni 2017, Biel/Bienne (GV)
     * **Wann:** Sonntag, 2017-06-18 ab 13:00 Uhr im Rahmen der [Cosin](https://www.cosin.ch/)
     * **Wo:** Villa Ritter in Biel/Bienne
@@ -20,6 +20,11 @@ Ca. alle zwei Monate führt der CCC-CH ein Gettogether durch. Ein Treffen aller 
 
 ## Vergangene Gettogether
 
+ * Dezember 2016, Hamburg
+    * **Wann:** Donnerstag, 2016-12-29 ab 16:00 Uhr (Tag 3 des 33c3)
+    * **Wo:** [Hall C.1](https://events.ccc.de/congress/2016/wiki/Room:Hall_C.1), 33c3, CCH Congress Center Hamburg, Deutschland
+    * **Traktanden:** [Pad](https://pads.ccc-ch.ch/public_pad/33c3-gettogether)
+    * **Link:** [Congress wiki](https://events.ccc.de/congress/2016/wiki/Session:CCC-CH_Gettogether)
  *  Dezember 2016, Rapperswil-Jona
     * **Wann:** Samstag, 2016-12-03 ab 14:30 Uhr
     * **Wo:** [Coredump](https://www.coredump.ch/kontakt/#kontakt_adresse), Zürcherstrasse 6 (4. Stock), 8640 Rapperswil-Jona

--- a/content/pages/de/intern/oktober13_gettogether.md
+++ b/content/pages/de/intern/oktober13_gettogether.md
@@ -1,0 +1,45 @@
+Title: CCC-CH Gettogether vom 2013-10-13
+Slug: oktober13_gettogether
+Lang: de
+Date: 2013-10-13
+Modified: 2017-04-25
+
+Das letzte Schweizweite Treffen war wieder ein Schritt weiter in unserer ausarbeitung des CCC-CH.
+
+Dank der tollen Gastfreundschaft der Kollegen des [Odenwilusenz Hackerspaces](http://odenwilusenz.ch/) konnten wir von kühler Mate, Cola und warmen Kaffee geniessen. Es war warm, hatte Internet und faszinierende automatische Türen.
+
+## Was wurde besprochen ##
+ * Budget wird überarbeitet.
+ * wir brauchen eine Teilnehmerzählung der Verbandsmitglieder. (aka wer von n-Leuten will sich beim CCC-CH beteiligen. Keine namen, keine ID)
+ * Wir haben vier weitere Mitarbeiter. Danilo, HPO, WENE und Tony.
+   * Danilo wird sich in zukunft um die Homepage kümmern.
+   * Wene und Tony werden uns mit den Treffen und Organisation helfen.
+   * HPO wird uns mit seiner Expertise in Rechsfragen beistehen.
+ * Sie Bewerben sich, hiermit auch auf eine Stelle im Vorstand.
+
+## 30C3 ##
+ * Bahn oder Bus transport wird noch weiter abgeklährt.
+ * Kollektiv Hotel suche, wird noch ein Freiwilliger gesucht.
+ * Tickets kann man noch nicht erwärben.
+
+## Webseit ##
+ * Danilo kümmerst sich in zukunft um updates und erweiterung des Angebots.
+
+## Wau-Holland-Stiftung / Cryptoparties ##
+ * Die Wau-Holland-Stiftung hat immer noch finanzielle Mittel für Cryptoparties zur verfügung. Anfragen dirkt an vorstand@wauland.de .
+
+## Mitglieder ##
+Zur Zeit sind Mitglieder:
+
+ * St.Gallen
+ * Winterthur
+ * Zürich
+ * Hackerfunk
+ * Beringen
+ * Basel
+ * Bern
+ * Freiburg
+
+Anwärter:
+
+ * Rapperswil


### PR DESCRIPTION
Infos zum Gettogether vom April 2017

Ausserdem hat mir Bluetonyum Infos zu einem alten Gettogether aus dem Oktober 2013 zukommen lassen. Ich habe diese auch in die Liste aufgenommen. Da zu diesem alten Gettogether kein Pad bekannt ist, habe ich die Infos kurzerhand auf unsere Seite übernommen.